### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "clouddeploy",
     "name_pretty": "Google Cloud Deploy",
     "product_documentation": "https://cloud.google.com/deploy/",
-    "client_documentation": "https://googleapis.dev/python/clouddeploy/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/clouddeploy/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Scale pipelines across your organization, while having  a cross-project, central
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-deploy.svg
    :target: https://pypi.org/project/google-cloud-deploy/
 .. _Google Cloud Deploy: https://cloud.google.com/deploy
-.. _Client Library Documentation: https://googleapis.dev/python/clouddeploy/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/clouddeploy/latest
 .. _Product Documentation:  https://cloud.google.com/deploy/docs
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.